### PR TITLE
Clean up logging assignments

### DIFF
--- a/fakegato-history.js
+++ b/fakegato-history.js
@@ -8,11 +8,11 @@ const moment = require('moment');
 const EPOCH_OFFSET = 978307200;
 
 const TYPE_ENERGY  = 'energy',
-      TYPE_ROOM    = 'room',
-      TYPE_WEATHER = 'weather',
-      TYPE_DOOR    = 'door',
-      TYPE_MOTION  = 'motion',
-      TYPE_THERMO  = 'thermo';
+	  TYPE_ROOM    = 'room',
+	  TYPE_WEATHER = 'weather',
+	  TYPE_DOOR    = 'door',
+	  TYPE_MOTION  = 'motion',
+	  TYPE_THERMO  = 'thermo';
 
 var homebridge;
 var Characteristic, Service;
@@ -145,7 +145,11 @@ module.exports = function (pHomebridge) {
 			this.size = size || 4032 ;
 			this.minutes = minutes || 10; // Optional timer length
 			this.accessoryName = accessory.displayName;
-			this.log = accessory.log;
+			this.log = accessory.log || {};
+
+			if (!this.log.debug) {
+				this.log.debug = function() {};
+			}
 
 			if (homebridge.globalFakeGatoTimer === undefined)
 				homebridge.globalFakeGatoTimer = new FakeGatoTimer({

--- a/fakegato-timer.js
+++ b/fakegato-timer.js
@@ -13,9 +13,9 @@ class FakeGatoTimer {
 		this.intervalID = null;
 		this.running = false;
 		this.log = params.log || {};
-		if (!params.log || !params.log.debug) {
-			if(DEBUG) this.log.debug = console.log;
-			else this.log.debug = function(){};
+
+		if (!this.log.debug) {
+			this.log.debug = DEBUG ? console.log : function() {};
 		}
 	}
 


### PR DESCRIPTION
Clean up....

- Convert outstanding `spaces` to `tabs`
- Add a fallback to `console.log`, if `accessory.log` doesn't exist
- Rewrite `this.log.debug` fallback assignment as a ternary statement