### PR TITLE
Fix returning write response value

### DIFF
--- a/fakegato-history.js
+++ b/fakegato-history.js
@@ -821,7 +821,7 @@ module.exports = function (pHomebridge) {
 
 
 		setCurrentS2W1(val, callback) {
-			callback(null, val);
+			callback(null);
 			this.log.debug("Data request %s: %s", this.accessoryName, base64ToHex(val));
 			var valHex = base64ToHex(val);
 			var substring = valHex.substring(4, 12);
@@ -836,7 +836,7 @@ module.exports = function (pHomebridge) {
 
 		setCurrentS2W2(val, callback) {
 			this.log.debug("Clock adjust %s: %s", this.accessoryName, base64ToHex(val));
-			callback(null, val);
+			callback(null);
 		}
 
 	}


### PR DESCRIPTION
Homebridge v1.3 (tested with Beta 22) displays a warning for returning a "write response" value if the characteristic itself does not support it.

Example Warning:
```
[12.11.2020, 22:30:28] Received warning for the plugin 'homebridge-test' from the characteristic 'S2W2': SET handler returned write response value, though the characteristic doesn't support write response!
[12.11.2020, 22:30:28] SET handler returned write response value, though the characteristic doesn't support write response!
```