### PR TITLE
Fixed missing UUID for FakeGatoHistory service.

### DIFF
--- a/fakegato-history.js
+++ b/fakegato-history.js
@@ -876,7 +876,7 @@ module.exports = function (pHomebridge) {
 
 	}
 
-	FakeGatoHistoryService.UUID = 'E863F007-079E-48FF-8F27-9C2605A29F52';
+	FakeGatoHistory.UUID = 'E863F007-079E-48FF-8F27-9C2605A29F52';
 
 	return FakeGatoHistory;
 };


### PR DESCRIPTION
The exported service FakeGatoHistory has no UUID assigned.